### PR TITLE
fix: allow missing previousData

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -66,7 +66,10 @@ const buildUpdateVariables = (resource, aorFetchType, params, queryType) =>
 
         // TODO: To overcome this permission issue,
         // it would be better to allow only permitted inputFields from *_set_input INPUT_OBJECT
-        if (params.data[key] === params.previousData[key]) {
+        if (
+            params.previousData &&
+            params.data[key] === params.previousData[key]
+        ) {
             return acc;
         }
 


### PR DESCRIPTION
`previousData` isn't present when using the useMutation hook with [the example from react-admin's docs](https://marmelab.com/react-admin/Actions.html#usemutation-hook).

This PR ensures `previousData` is defined before trying to access it. I tested this locally and it fixed my error.

