### PR TITLE
Enhance filter variables to support arrays

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -24,10 +24,9 @@ const buildGetListVariables = introspectionResults => (
         let filter;
         if (key === 'ids') {
             filter = { id: { _in: filterObj['ids'] } };
-        
-	} else if(Array.isArray(filterObj[key])) {
-		filter = { [key]: { _in: filterObj[key] } };
-	} else {
+        } else if (Array.isArray(filterObj[key])) {
+		    filter = { [key]: { _in: filterObj[key] } };
+        } else {
             const field = resource.type.fields.find(f => f.name === key);
             switch (getFinalType(field.type).name) {
                 case 'String':

--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -24,7 +24,10 @@ const buildGetListVariables = introspectionResults => (
         let filter;
         if (key === 'ids') {
             filter = { id: { _in: filterObj['ids'] } };
-        } else {
+        
+	} else if(Array.isArray(filterObj[key])) {
+		filter = { [key]: { _in: filterObj[key] } };
+	} else {
             const field = resource.type.fields.find(f => f.name === key);
             switch (getFinalType(field.type).name) {
                 case 'String':


### PR DESCRIPTION
This pull request checks if the filter type is an array and uses the _in operator instead. 