### PR TITLE
Handle sort via relationship fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,29 @@ And generates the following variables to be passed along side the query:
 
 ```
 
+### Sorting
+
+Dot notation is supported for sort fields, and will be expanded into an object in the graphQL query.
+
+For example:
+```
+export const PostList = (props) => (
+    <List {...props} sort={{ field: 'user.email', order: 'DESC' }}>
+        ...
+    </List>
+);
+```
+
+Will generate the following graphQL query:
+```
+{
+  limit: 25,
+  offset: 0,
+  order_by: { user: { email: 'desc' } }
+}
+```
+
+
 ## Options
 
 ### Customize the Apollo client

--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
     GET_ONE,
     GET_LIST,
@@ -49,9 +50,7 @@ const buildGetListVariables = introspectionResults => (
     }
 
     if (params.sort) {
-        result['order_by'] = {
-            [params.sort.field]: params.sort.order.toLowerCase(),
-        };
+        result['order_by'] = _.set({}, params.sort.field, params.sort.order.toLowerCase());
     }
 
     return result;


### PR DESCRIPTION
One can use a field from a relation to sort using dot notation, e.g.:
```
      <ReferenceField source="user_id" reference="users" sortBy="users.email">
        <TextField source="email" />
      </ReferenceField>
```

This `users.email` will be transformed into an object for the `order_by`:
```
order_by: {users: {email: 'asc'}}
```
instead of previously:
```
order_by: {users.email: 'asc'}
``` 
which didn't work obviously