### PR TITLE
Add support to change fields for query

### DIFF
--- a/src/buildGqlQuery.js
+++ b/src/buildGqlQuery.js
@@ -28,15 +28,15 @@ export const buildFragments = introspectionResults => possibleTypes =>
             ...acc,
             gqlTypes.inlineFragment(
                 gqlTypes.selectionSet(
-                    buildFields(introspectionResults)(linkedType.fields)
+                    buildFields(linkedType)
                 ),
                 gqlTypes.namedType(gqlTypes.name(type.name))
             ),
         ];
     }, []);
 
-export const buildFields = fields =>
-    fields.reduce((acc, field) => {
+export const buildFields = type =>
+    type.fields.reduce((acc, field) => {
         const type = getFinalType(field.type);
 
         if (type.name.startsWith('_')) {
@@ -164,17 +164,17 @@ export const buildApolloArgs = (query, variables) => {
     return args;
 };
 
-export default introspectionResults => (
+export const buildGqlQuery = (introspectionResults, buildFields, buildMetaArgs, buildArgs, buildApolloArgs) => (
     resource,
     aorFetchType,
     queryType,
-    variables
+    variables,
 ) => {
     const { sortField, sortOrder, ...metaVariables } = variables;
     const apolloArgs = buildApolloArgs(queryType, variables);
     const args = buildArgs(queryType, variables);
     const metaArgs = buildMetaArgs(queryType, metaVariables, aorFetchType);
-    const fields = buildFields(resource.type.fields);
+    const fields = buildFields(resource.type);
     if (
         aorFetchType === GET_LIST ||
         aorFetchType === GET_MANY ||
@@ -265,3 +265,5 @@ export default introspectionResults => (
         ),
     ]);
 };
+
+export default introspectionResults => buildGqlQuery(introspectionResults, buildFields, buildMetaArgs, buildArgs, buildApolloArgs)

--- a/src/buildGqlQuery.js
+++ b/src/buildGqlQuery.js
@@ -35,7 +35,7 @@ export const buildFragments = introspectionResults => possibleTypes =>
         ];
     }, []);
 
-export const buildFields = introspectionResults => fields =>
+export const buildFields = fields =>
     fields.reduce((acc, field) => {
         const type = getFinalType(field.type);
 
@@ -174,7 +174,7 @@ export default introspectionResults => (
     const apolloArgs = buildApolloArgs(queryType, variables);
     const args = buildArgs(queryType, variables);
     const metaArgs = buildMetaArgs(queryType, metaVariables, aorFetchType);
-    const fields = buildFields(introspectionResults)(resource.type.fields);
+    const fields = buildFields(resource.type.fields);
     if (
         aorFetchType === GET_LIST ||
         aorFetchType === GET_MANY ||


### PR DESCRIPTION
I have the requirement to select additional fields from relations in a m-n table for the list view.
I could not access the buildFields function from my code.

With this change, which should be backwards-compatible we have the possibility to access the buildFields function and add for example related entities.

```
import buildDataProvider from 'ra-data-hasura-graphql'
import { buildQueryFactory } from 'ra-data-hasura-graphql/src/buildQuery'
import buildVariables from 'ra-data-hasura-graphql/src/buildVariables'
import { buildGqlQuery, buildFields, buildMetaArgs, buildArgs, buildApolloArgs } from 'ra-data-hasura-graphql/src/buildGqlQuery'
import getResponseParser from 'ra-data-hasura-graphql/src/getResponseParser'
import * as gqlTypes from 'graphql-ast-types-browser';

const buildFieldsCustom = type => {
  let res = buildFields(type)
  if(type.name === "app") {
    // here we add additional fields we want to query for apps.
    // we are using the graphql-ast-types functions which is ast representation for graphql
    res.push(gqlTypes.field(gqlTypes.name("app_berechtigungs"), null, null, null, gqlTypes.selectionSet([
      gqlTypes.field(gqlTypes.name("berechtigung_id")),
      gqlTypes.field(gqlTypes.name("berechtigung"), null, null, null, gqlTypes.selectionSet([
        gqlTypes.field(gqlTypes.name("name"))
      ]))
    ])))
  }
  return res
}
const buildGqlQueryCustom = iR => buildGqlQuery(iR, buildFieldsCustom, buildMetaArgs, buildArgs, buildApolloArgs)
const buildQuery = buildQueryFactory(buildVariables, buildGqlQueryCustom, getResponseParser)
buildDataProvider({...opt, buildQuery})
```