### PR TITLE
Make it possible to filter based on a nested field

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -54,6 +54,16 @@ const buildGetListVariables = (introspectionResults) => (
     };
   }, {});
   filterObj = omit(filterObj, orFilterKeys);
+
+  const makeNestedFilter = (obj, operation) => {
+    if (Object.keys(obj).length === 1) {
+      const [key] = Object.keys(obj);
+      return { [key]: makeNestedFilter(obj[key], operation) };
+    } else {
+      return { [operation]: obj };
+    }
+  };
+
   const filterReducer = (obj) => (acc, key) => {
     let filter;
     if (key === 'ids') {
@@ -65,19 +75,22 @@ const buildGetListVariables = (introspectionResults) => (
     } else {
       let [keyName, operation = ''] = key.split('@');
       const field = resource.type.fields.find((f) => f.name === keyName);
-      switch (getFinalType(field.type).name) {
-        case 'String':
-          operation = operation || '_ilike';
-          filter = {
-            [keyName]: {
-              [operation]: operation.includes('like')
-                ? `%${obj[key]}%`
-                : obj[key],
-            },
-          };
-          break;
-        default:
-          filter = { [keyName]: { [operation || '_eq']: obj[key] } };
+      const finalType = getFinalType(field.type);
+      if (finalType.name === 'String') {
+        operation = operation || '_ilike';
+        filter = {
+          [keyName]: {
+            [operation]: operation.includes('like')
+              ? `%${obj[key]}%`
+              : obj[key],
+          },
+        };
+      } else if (finalType.kind === 'OBJECT') {
+        operation = operation || '_eq';
+        filter = { [keyName]: makeNestedFilter(obj[keyName], operation) };
+      } else {
+        operation = operation || '_eq';
+        filter = { [keyName]: { [operation]: obj[key] } };
       }
     }
     return [...acc, filter];


### PR DESCRIPTION
With this fix you could have a list filter that filters on a nested object field, for example doing

```tsx

const ProductListFilter = (props: any) => (
  <Filter {...props}>
    <SelectInput
      label="Status"
      source="category.status"
      choices={[
        { id: "in_production", name: "In Production" },
        { id: "planned", name: "Planned" },
        { id: "retired", name: "Retired" }
      ]}
      emptyText="All"
      alwaysOn
    />
  </Filter>
);

export const ProductList = (props: any) => (
  <List
    {...props}
    filters={<ProductListFilter />}
    sort={{ field: "planting_date", order: "ASC" }}
    filterDefaultValues={{ category: { status: "in_production" } }}
  >
    .....
```