### PR TITLE
Make it possible to reference a nested object in a reference many field

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -142,6 +142,20 @@ const buildCreateVariables = (resource, aorFetchType, params, queryType) => {
   return params.data;
 };
 
+const makeNestedTarget = (target, id) =>
+  // This simple example should make clear what this function does
+  // makeNestedTarget("a.b", 42)
+  // => { a: { b: { _eq: 42 } } }
+  target
+    .split('.')
+    .reverse()
+    .reduce(
+      (acc, key) => ({
+        [key]: acc,
+      }),
+      { _eq: id }
+    );
+
 export default (introspectionResults) => (
   resource,
   aorFetchType,
@@ -169,16 +183,14 @@ export default (introspectionResults) => (
           where: {
             _and: [
               ...built['where']['_and'],
-              { [params.target]: { _eq: params.id } },
+              makeNestedTarget(params.target, params.id),
             ],
           },
         };
       }
       return {
         ...built,
-        where: {
-          [params.target]: { _eq: params.id },
-        },
+        where: makeNestedTarget(params.target, params.id),
       };
     }
     case GET_MANY:


### PR DESCRIPTION
For example if you have countries associated to book authors, and you want to show all books for a given country you could now do

```tsx
const CountryShow = (props: any) => {
  return (
    <Show {...props}>
      <SimpleShowLayout>
        <TextField source="name" />
        <ReferenceManyField
          perPage={5}
          label="Book"
          reference="book"
          target="author.country_id"
          sort={{ field: "written", order: "DESC" }}
        >
          <Datagrid rowClick="show">
            <TextField source="name" />
            <DateField source="written" />
            <DateField source="published" />
          </Datagrid>
        </ReferenceManyField>
      </SimpleShowLayout>
    </Show>
  );
};
```